### PR TITLE
Add Nengo license info

### DIFF
--- a/nengo/CONTRIBUTORS.rst
+++ b/nengo/CONTRIBUTORS.rst
@@ -1,0 +1,41 @@
+******************
+Nengo contributors
+******************
+
+This is a list of people who have contributed to Nengo.
+Note that this is not the list of copyright holders;
+Applied Brain Research Inc. holds the copyright to
+all Nengo code, except for code that is used under
+various licenses, as described in the ``LICENSE.rst`` file.
+
+By adding your name to this file, you are agreeing to the
+`Nengo Contributor Assignment Agreement <https://nengo.github.io/caa.html>`_.
+If you agree, then add yourself to the file like so::
+
+  - Name <email address>
+
+Please keep this list sorted alphabetically.
+
+- Aaron Voelker <arvoelke@gmail.com>
+- Andrew Mundy <andrew.mundy@ieee.org>
+- Ben Morcos <morcos.ben@gmail.com>
+- Brent Komer <brent.komer@gmail.com>
+- Bryan Tripp <bptripp@uwaterloo.ca>
+- Chris Eliasmith <celiasmith@uwaterloo.ca>
+- Daniel Rasmussen <drasmuss@uwaterloo.ca>
+- Eric Crawford <e2crawfo@uwaterloo.ca>
+- Eric Hunsberger <erichuns@gmail.com>
+- Genevieve Serafin <mgserafi@uwaterloo.ca>
+- Ivana Kajić <ivana.kajic@gmail.com>
+- James Bergstra <james.bergstra@gmail.com>
+- Jan Gosmann <jan@hyper-world.de>
+- Oliver Trujillo <olivertgp@hotmail.com>
+- Peter Blouw <pblouw@uwaterloo.ca>
+- Peter Suma <psuma@waterloo.ca>
+- Sean Aubin <seanaubin@gmail.com>
+- Sugandha Sharma <sugandha974@gmail.com>
+- Terry Stewart <terry.stewart@gmail.com>
+- Travis DeWolf <travis.dewolf@gmail.com>
+- Trevor Bekolay <tbekolay@gmail.com>
+- Xuan Choo <xchoo.mainframe@gmail.com>
+- Youssef Zaky <youssefzaky@gmail.com>

--- a/nengo/LICENSE.rst
+++ b/nengo/LICENSE.rst
@@ -1,0 +1,165 @@
+*************
+Nengo license
+*************
+
+Nengo is made available under a proprietary license that permits
+using, copying, sharing, and making derivative works
+from Nengo and its source code for any non-commercial purpose.
+
+If you would like to use Nengo commercially, licenses can be
+purchased from Applied Brain Research, Inc. Please contact
+info@appliedbrainresearch.com for more information.
+
+*************
+Licensed code
+*************
+
+Nengo imports several open source libraries.
+
+* `NumPy <http://www.numpy.org/>`_ - Used under
+  `BSD license <http://www.numpy.org/license.html>`__
+* `Sphinx <http://sphinx-doc.org/>`_ - Used under
+  `BSD license <https://bitbucket.org/birkenfeld/sphinx/src/be5bd373a1a47fb68d70523b6e980e654e070e9f/LICENSE?at=default>`__
+* `numpydoc <https://github.com/numpy/numpydoc>`_ - Used under
+  `BSD license <https://github.com/numpy/numpydoc/blob/master/LICENSE.txt>`__
+* `matplotlib <http://matplotlib.org/>`_ - Used under
+  `modified PSF license <http://matplotlib.org/users/license.html>`__
+* `IPython <http://ipython.org/>`_ - Used under
+  `BSD license <https://github.com/ipython/ipython/blob/master/COPYING.rst>`__
+* `pytest <http://pytest.org/latest/>`_ - Used under
+  `MIT license <http://docs.pytest.org/en/latest/license.html>`__
+
+Nengo also includes code modified from other libraries.
+
+------------
+
+The file ``nengo/builder/operator.py`` contains code with the following
+license:
+
+Copyright (c) 2014, James Bergstra
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+------------
+
+The file ``nengo/utils/magic.py`` contains code with the
+following license:
+
+Copyright (c) 2013, Graham Dumpleton. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+------------
+
+The file ``nengo/utils/graphs.py`` contains code with the following
+license:
+
+Theano is copyright (c) 2008-2013 Theano Development Team.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+* Neither the name of Theano nor the names of its contributors may be
+  used to endorse or promote products derived from this software
+  without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+------------
+
+The file ``nengo/utils/filter_design.py`` contains code with the
+following license:
+
+Copyright (c) 2001, 2002 Enthought, Inc.
+All rights reserved.
+
+Copyright (c) 2003-2012 SciPy Developers.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+a. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+b. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+c. Neither the name of Enthought nor the names of the SciPy Developers
+   may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.

--- a/nengo/README.md
+++ b/nengo/README.md
@@ -1,3 +1,9 @@
-Extension of the code developed by Eric Hunsberger: https://github.com/nengo/nengo/tree/nengo_ocl.
+Extension of the code developed by Eric Hunsberger and others: https://github.com/nengo/nengo
 
 Added PresentInput3d, Convolution3d and Pooling3d processes to work with videos.
+
+----
+
+Nengo is developed and maintained by Applied Brain Research,
+and is used under its [license](LICENSE.rst),
+which makes Nengo available free of charge for non-commercial purposes.

--- a/nengo_ocl/CONTRIBUTORS.rst
+++ b/nengo_ocl/CONTRIBUTORS.rst
@@ -1,0 +1,25 @@
+**********************
+Nengo OCL contributors
+**********************
+
+This is a list of people who have contributed to Nengo OCL.
+Note that this is not the list of copyright holders;
+Applied Brain Research Inc. holds the copyright to
+all Nengo OCL code, except for code that is used under
+various licenses, as described in the ``LICENSE.rst`` file.
+
+By adding your name to this file, you are agreeing
+to the Contributor Assignment Agreement found in
+the ``LICENSE.rst`` file. If you agree, then add yourself
+to the file like so::
+
+  - Name <email address>
+
+Please keep this list sorted alphabetically by first name.
+
+- Bryan Tripp <bptripp@uwaterloo.ca>
+- Eric Hunsberger <erichuns@gmail.com>
+- Ménélik Vero <menelik.vero@tum.de>
+- Shaun Ren <shaun.ren@linux.com>
+- Trevor Bekolay <tbekolay@gmail.com>
+- Xuan Choo <xchoo.mainframe@gmail.com>

--- a/nengo_ocl/LICENSE.rst
+++ b/nengo_ocl/LICENSE.rst
@@ -1,0 +1,259 @@
+*****************
+Nengo OCL license
+*****************
+
+Nengo OCL is made available under a proprietary license that permits
+using, copying, sharing, and making derivative works
+from Nengo OCL and its source code for any non-commercial purpose.
+
+If you would like to use Nengo OCL commercially, licenses can be
+purchased from Applied Brain Research, Inc. Please contact
+info@appliedbrainresearch.com for more information.
+
+*************
+Licensed code
+*************
+
+Nengo OCL imports several open source libraries.
+
+* `NumPy <http://www.numpy.org/>`_ - Used under
+  `BSD license <http://www.numpy.org/license.html>`_
+* `NetworkX <https://networkx.github.io/>`_ - Used under
+  `BSD license <http://networkx.github.io/documentation/networkx-1.9.1/reference/legal.html>`_
+* `PyOpenCL <http://mathema.tician.de/software/pyopencl/>`_ - Used under
+  `MIT license <http://documen.tician.de/pyopencl/misc.html#license>`_
+
+------------
+
+A majority of the code prior to October 10, 2014
+is copyright James Bergstra,
+and is included in this repository under the terms of
+a transferable royalty-free license
+granted to Applied Brain Research Inc.
+Please contact info@appliedbrainresearch.com
+for more information.
+
+********************************
+Contributor Assignment Agreement
+********************************
+
+Based on Harmony (HA-CAA-I-ANY) Version 1.0, with minor changes.
+
+Nengo OCL Individual Contributor Assignment Agreement
+=====================================================
+
+Thank you for your interest in contributing to Nengo OCL, a product of
+Applied Brain Research ("We" or "Us").
+
+This contributor agreement (the "Agreement") documents the rights
+granted by contributors to Us.
+
+By adding your name to the CONTRIBUTORS.rst file at
+<https://github.com/nengo/nengo_ocl/blob/master/CONTRIBUTORS.rst>
+you are agreeing to be bound by the Agreement in full.
+
+You agree to inform Us in the relevant pull request(s) if You do not own
+the Copyright to the entire Submission. We will initiate an IP review
+with You to determine the eligibility of the Submission before merging
+the pull request.
+
+This is a legally binding document, so please read it carefully before
+agreeing to it. The Agreement may cover more than one software project
+managed by Us.
+
+1. Definitions
+--------------
+
+"You" means the individual who Submits a Contribution to Us.
+
+"Contribution" means any work of authorship that is Submitted by You
+to Us in which You own or assert ownership of the Copyright.
+
+"Copyright" means all rights protecting works of authorship owned or
+controlled by You, including copyright, moral and neighboring rights,
+as appropriate, for the full term of their existence including any
+extensions by You.
+
+"Material" means the work of authorship which is made available by Us
+to third parties. When this Agreement covers more than one software
+project, the Material means the work of authorship to which the
+Contribution was Submitted. After You Submit the Contribution, it may
+be included in the Material.
+
+"Submit," "Submission" means any form of electronic, verbal, or written
+communication (including any and all Contributions and works of
+authorship) sent to Us or our representatives, including but not limited
+to electronic mailing lists, source code control systems, and issue
+tracking systems that are managed by, or on behalf of, Us for the
+purpose of discussing and improving the Material, but excluding
+communication that is conspicuously marked or otherwise designated in
+writing by You as "Not a Contribution."
+
+"Submission Date" means the date on which You Submit a Contribution to
+Us.
+
+"Effective Date" means the date You execute this Agreement or the date
+You first Submit a Contribution to Us, whichever is earlier.
+
+2. Grant of Rights
+------------------
+
+2.1 Copyright Assignment
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+(a) At the time the Contribution is Submitted, You assign to Us all
+    right, title, and interest worldwide in all Copyright covering the
+    Contribution; provided that this transfer is conditioned upon
+    compliance with Section 2.3.
+
+(b) To the extent that any of the rights in Section 2.1(a) cannot be
+    assigned by You to Us, You grant to Us a perpetual, worldwide,
+    exclusive, royalty-free, transferable, irrevocable license under
+    such non-assigned rights, with rights to sublicense through
+    multiple tiers of sublicensees, to practice such non-assigned
+    rights, including, but not limited to, the right to reproduce,
+    modify, display, perform and distribute the Contribution; provided
+    that this license is conditioned upon compliance with Section 2.3.
+
+(c) To the extent that any of the rights in Section 2.1(a) can neither
+    be assigned nor licensed by You to Us, You irrevocably waive and
+    agree never to assert such rights against Us, any of our
+    successors in interest, or any of our licensees, either direct or
+    indirect; provided that this agreement not to assert is
+    conditioned upon compliance with Section 2.3.
+
+(d) Upon such transfer of rights to Us, to the maximum extent
+    possible, We immediately grant to You a perpetual, worldwide,
+    non-exclusive, royalty-free, transferable, irrevocable license
+    under such rights covering the Contribution, with rights to
+    sublicense through multiple tiers of sublicensees, to reproduce,
+    modify, display, perform, and distribute the Contribution. The
+    intention of the parties is that this license will be as broad as
+    possible and to provide You with rights as similar as possible to
+    the owner of the rights that You transferred. This license back is
+    limited to the Contribution and does not provide any rights to the
+    Material.
+
+2.2 Patent License
+^^^^^^^^^^^^^^^^^^
+
+For patent claims including, without limitation, method, process, and
+apparatus claims which You own, control or have the right to grant,
+now or in the future, You grant to Us a perpetual, worldwide,
+non-exclusive, transferable, royalty-free, irrevocable patent license,
+with the right to sublicense these rights to multiple tiers of
+sublicensees, to make, have made, use, sell, offer for sale, import
+and otherwise transfer the Contribution and the Contribution in
+combination with the Material (and portions of such combination). This
+license is granted only to the extent that the exercise of the
+licensed rights infringes such patent claims; and provided that this
+license is conditioned upon compliance with Section 2.3.
+
+2.3 Outbound License
+^^^^^^^^^^^^^^^^^^^^
+
+Based on the grant of rights in Sections 2.1 and 2.2, if We include
+Your Contribution in a Material, We may license the Contribution under
+any license, including copyleft, permissive, commercial, or
+proprietary licenses. As a condition on the exercise of this right, We
+agree to also license the Contribution under the terms of the license
+or licenses which We are using for the Material on the Submission
+Date.
+
+2.4 Moral Rights
+^^^^^^^^^^^^^^^^
+
+If moral rights apply to the Contribution, to the maximum extent
+permitted by law, You waive and agree not to assert such moral rights
+against Us or our successors in interest, or any of our licensees,
+either direct or indirect.
+
+2.5 Our Rights
+^^^^^^^^^^^^^^
+
+You acknowledge that We are not obligated to use Your Contribution as
+part of the Material and may decide to include any Contribution We
+consider appropriate.
+
+2.6 Reservation of Rights
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Any rights not expressly assigned or licensed under this section are
+expressly reserved by You.
+
+3. Agreement
+------------
+
+You confirm that:
+
+(a) You have the legal authority to enter into this Agreement.
+
+(b) You own the Copyright and patent claims covering the Contribution
+    which are required to grant the rights under Section 2.
+
+(c) The grant of rights under Section 2 does not violate any grant of
+    rights which You have made to third parties, including Your
+    employer. If You are an employee, You have had Your employer
+    approve this Agreement or sign the Entity version of this
+    document. If You are less than eighteen years old, please have
+    Your parents or guardian sign the Agreement.
+
+(d) You have informed us in the relevant pull request(s) if You do not
+    own the Copyright to the entire Submission.
+
+4. Disclaimer
+-------------
+
+EXCEPT FOR THE EXPRESS WARRANTIES IN SECTION 3, THE CONTRIBUTION IS
+PROVIDED "AS IS". MORE PARTICULARLY, ALL EXPRESS OR IMPLIED WARRANTIES
+INCLUDING, WITHOUT LIMITATION, ANY IMPLIED WARRANTY OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ARE EXPRESSLY DISCLAIMED BY YOU TO US AND BY US TO YOU. TO THE EXTENT
+THAT ANY SUCH WARRANTIES CANNOT BE DISCLAIMED, SUCH WARRANTY IS
+LIMITED IN DURATION TO THE MINIMUM PERIOD PERMITTED BY LAW.
+
+5. Consequential Damage Waiver
+------------------------------
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT WILL
+YOU OR US BE LIABLE FOR ANY LOSS OF PROFITS, LOSS OF ANTICIPATED
+SAVINGS, LOSS OF DATA, INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL
+AND EXEMPLARY DAMAGES ARISING OUT OF THIS AGREEMENT REGARDLESS OF THE
+LEGAL OR EQUITABLE THEORY (CONTRACT, TORT OR OTHERWISE) UPON WHICH THE
+CLAIM IS BASED.
+
+6. Miscellaneous
+----------------
+
+**6.1** This Agreement will be governed by and construed in accordance
+with the laws of Ontario, Canada excluding its conflicts of law
+provisions. Under certain circumstances, the governing law in this
+section might be superseded by the United Nations Convention on
+Contracts for the International Sale of Goods ("UN Convention") and the
+parties intend to avoid the application of the UN Convention to this
+Agreement and, thus, exclude the application of the UN Convention in its
+entirety to this Agreement.
+
+**6.2** This Agreement sets out the entire agreement between You and
+Us for Your Contributions to Us and overrides all other agreements or
+understandings.
+
+**6.3** If You or We assign the rights or obligations received through
+this Agreement to a third party, as a condition of the assignment,
+that third party must agree in writing to abide by all the rights and
+obligations in the Agreement.
+
+**6.4** The failure of either party to require performance by the
+other party of any provision of this Agreement in one situation shall
+not affect the right of a party to require such performance at any
+time in the future. A waiver of performance under a provision in one
+situation shall not be considered a waiver of the performance of the
+provision in the future or a waiver of the provision in its entirety.
+
+**6.5** If any provision of this Agreement is found void and
+unenforceable, such provision will be replaced to the extent possible
+with a provision that comes closest to the meaning of the original
+provision and which is enforceable. The terms and conditions set forth
+in this Agreement shall apply notwithstanding any failure of essential
+purpose of this Agreement or any limited remedy to the maximum extent
+possible under law.

--- a/nengo_ocl/README.md
+++ b/nengo_ocl/README.md
@@ -1,5 +1,11 @@
-Extension of the code developed by Eric Hunsberger: https://github.com/nengo/nengo_ocl.
+Extension of the code developed by Eric Hunsberger and others: https://github.com/nengo/nengo_ocl
 
 Added PresentInput3d, Convolution3d and Pooling3d processes to work with videos.
 
 P.S. pay attention to GPU local size settings in "clra_nonlinearities.py"
+
+----
+
+Nengo OpenCL is maintained by Applied Brain Research,
+and is used under its [license](LICENSE.rst),
+which makes Nengo OpenCL available free of charge for non-commercial purposes.


### PR DESCRIPTION
Hi @MarcoSaku, this work looks very cool, thanks for building it using Nengo!

We've tried to make Nengo and Nengo OpenCL "pluggable" in the sense that you should be able to `pip install nengo nengo_ocl` instead of including all of the source code in your repo; it should be possible for you to have `PresentInput3d`, `Convolution3d` and `Pooling3d` in this repo and instead depend on a specific version of Nengo or Nengo OpenCL as a requirement. In doing so, the size of your repository would go down quite a bit, and it would be more clear what your unique contributions are.

However, making that change is a fair bit of work and this is presumably working now so no worries if you want to keep the nengo and nengo_ocl source in here. We would request that you keep the Nengo and Nengo OpenCL license information intact along with the source code so that it's clear to other people where to get Nengo and under what terms it can be used. This pull request adds those licenses in places that I think make sense, but please feel free to move them wherever makes sense to you!